### PR TITLE
エンティティクラスにプリフィックスを付けられるようにする

### DIFF
--- a/src/main/java/org/seasar/doma/extension/gen/DaoDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/DaoDescFactory.java
@@ -17,6 +17,8 @@ package org.seasar.doma.extension.gen;
 
 import org.seasar.doma.extension.gen.internal.util.ClassUtil;
 
+import java.util.Objects;
+
 /**
  * {@link DaoDesc} のファクトリです。
  * 
@@ -66,7 +68,10 @@ public class DaoDescFactory {
     public DaoDesc createDaoDesc(EntityDesc entityDesc) {
         DaoDesc daoDesc = new DaoDesc();
         daoDesc.setPackageName(packageName);
-        daoDesc.setSimpleName(entityDesc.getSimpleName() + suffix);
+        String entityPrefix = Objects.nonNull(entityDesc.getEntityPrefix()) ?
+                entityDesc.getEntityPrefix() : "";
+        String simpleName = entityPrefix + entityDesc.getSimpleName() + suffix;
+        daoDesc.setSimpleName(simpleName);
         if (configClassName != null) {
             daoDesc.setConfigClassSimpleName(ClassUtil
                     .getSimpleName(configClassName));

--- a/src/main/java/org/seasar/doma/extension/gen/DaoDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/DaoDescFactory.java
@@ -16,6 +16,7 @@
 package org.seasar.doma.extension.gen;
 
 import org.seasar.doma.extension.gen.internal.util.ClassUtil;
+import org.seasar.doma.extension.gen.internal.util.StringUtil;
 
 import java.util.Objects;
 
@@ -68,8 +69,7 @@ public class DaoDescFactory {
     public DaoDesc createDaoDesc(EntityDesc entityDesc) {
         DaoDesc daoDesc = new DaoDesc();
         daoDesc.setPackageName(packageName);
-        String entityPrefix = Objects.nonNull(entityDesc.getEntityPrefix()) ?
-                entityDesc.getEntityPrefix() : "";
+        String entityPrefix = StringUtil.defaultString(entityDesc.getEntityPrefix(), "");
         String simpleName = entityPrefix + entityDesc.getSimpleName() + suffix;
         daoDesc.setSimpleName(simpleName);
         if (configClassName != null) {

--- a/src/main/java/org/seasar/doma/extension/gen/DaoDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/DaoDescFactory.java
@@ -18,8 +18,6 @@ package org.seasar.doma.extension.gen;
 import org.seasar.doma.extension.gen.internal.util.ClassUtil;
 import org.seasar.doma.extension.gen.internal.util.StringUtil;
 
-import java.util.Objects;
-
 /**
  * {@link DaoDesc} のファクトリです。
  * 

--- a/src/main/java/org/seasar/doma/extension/gen/EntityDesc.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDesc.java
@@ -17,6 +17,7 @@ package org.seasar.doma.extension.gen;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * エンティティ記述です。
@@ -36,6 +37,9 @@ public class EntityDesc extends ClassDesc {
 
     /** テーブルの完全修飾名 */
     protected String qualifiedTableName;
+
+    /** エンティティクラスのプリフィックス */
+    protected String entityPrefix;
 
     /** スーパークラスの単純名 */
     protected String superclassSimpleName;
@@ -169,6 +173,25 @@ public class EntityDesc extends ClassDesc {
      */
     public String getTableName() {
         return tableName;
+    }
+
+    /**
+     * エンティティクラスのプリフィックスを返します。
+     *
+     * @return エンティティクラスのプリフィックス
+     */
+    public String getEntityPrefix() {
+        return entityPrefix;
+    }
+
+    /**
+     * エンティティクラスのプリフィックスを設定します。
+     *
+     * @param entityPrefix
+     *            エンティティクラスのプリフィックス
+     */
+    public void setEntityPrefix(String entityPrefix) {
+        this.entityPrefix = entityPrefix;
     }
 
     /**
@@ -453,6 +476,22 @@ public class EntityDesc extends ClassDesc {
      */
     public void setQualifiedTableName(String qualifiedTableName) {
         this.qualifiedTableName = qualifiedTableName;
+    }
+
+    /**
+     * 完全修飾名を返します。
+     *
+     * @return 完全修飾名
+     */
+    @Override
+    public String getQualifiedName() {
+        String prefix = Objects.nonNull(entityPrefix) ? entityPrefix : "";
+
+        if (packageName == null || packageName.isEmpty()) {
+            return prefix + simpleName;
+        }
+
+        return packageName + "." + prefix + simpleName;
     }
 
 }

--- a/src/main/java/org/seasar/doma/extension/gen/EntityDesc.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDesc.java
@@ -19,7 +19,6 @@ import org.seasar.doma.extension.gen.internal.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * エンティティ記述です。

--- a/src/main/java/org/seasar/doma/extension/gen/EntityDesc.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDesc.java
@@ -15,6 +15,8 @@
  */
 package org.seasar.doma.extension.gen;
 
+import org.seasar.doma.extension.gen.internal.util.StringUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -485,7 +487,7 @@ public class EntityDesc extends ClassDesc {
      */
     @Override
     public String getQualifiedName() {
-        String prefix = Objects.nonNull(entityPrefix) ? entityPrefix : "";
+        String prefix = StringUtil.defaultString(entityPrefix, "");
 
         if (packageName == null || packageName.isEmpty()) {
             return prefix + simpleName;

--- a/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.seasar.doma.Column;

--- a/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.seasar.doma.Column;
@@ -137,7 +138,21 @@ public class EntityDescFactory {
      */
     public EntityDesc createEntityDesc(TableMeta tableMeta) {
         String name = StringUtil.fromSnakeCaseToCamelCase(tableMeta.getName());
-        return createEntityDesc(tableMeta, StringUtil.capitalize(name));
+        return createEntityDesc(tableMeta, null, StringUtil.capitalize(name));
+    }
+
+    /**
+     * エンティティ記述を作成します。
+     *
+     * @param tableMeta
+     *            テーブルメタデータ
+     * @param entityPrefix
+     *            エンティティクラスのプリフィックス
+     * @return エンティティ記述
+     */
+    public EntityDesc createEntityDesc(TableMeta tableMeta, String entityPrefix) {
+        String name = StringUtil.fromSnakeCaseToCamelCase(tableMeta.getName());
+        return createEntityDesc(tableMeta, entityPrefix, StringUtil.capitalize(name));
     }
 
     /**
@@ -145,11 +160,14 @@ public class EntityDescFactory {
      * 
      * @param tableMeta
      *            テーブルメタデータ
+     * @param entityPrefix
+     *            エンティティクラスのプリフィックス
      * @param simpleName
      *            エンティティ名
      * @return エンティティ記述
      */
-    public EntityDesc createEntityDesc(TableMeta tableMeta, String simpleName) {
+    public EntityDesc createEntityDesc(TableMeta tableMeta,
+                                       String entityPrefix, String simpleName) {
         EntityDesc entityDesc = new EntityDesc();
         entityDesc.setNamingType(namingType);
         entityDesc.setOriginalStatesPropertyName(originalStatesPropertyName);
@@ -158,12 +176,13 @@ public class EntityDescFactory {
         entityDesc.setTableName(tableMeta.getName());
         entityDesc.setQualifiedTableName(tableMeta.getQualifiedTableName());
         entityDesc.setPackageName(packageName);
+        entityDesc.setEntityPrefix(Objects.nonNull(entityPrefix) ? entityPrefix : "");
         entityDesc.setSimpleName(simpleName);
         if (superclass != null) {
             entityDesc.setSuperclassSimpleName(superclass.getSimpleName());
         }
-        entityDesc.setListenerClassSimpleName(ClassUtil
-                .getSimpleName(entityDesc.getSimpleName()
+        entityDesc.setListenerClassSimpleName(entityDesc.getEntityPrefix()
+                + ClassUtil.getSimpleName(entityDesc.getSimpleName()
                         + Constants.ENTITY_LISTENER_SUFFIX));
         entityDesc.setCompositeId(tableMeta.hasCompositePrimaryKey());
         entityDesc.setComment(tableMeta.comment);
@@ -202,7 +221,9 @@ public class EntityDescFactory {
      * @return エンティティ名とテーブル名が異なる場合 {@code true}
      */
     protected boolean isNameDifferentBetweenEntityAndTable(EntityDesc entityDesc) {
-        String entityName = entityDesc.getSimpleName();
+        String entityPrefix = Objects.nonNull(entityDesc.getEntityPrefix()) ?
+                entityDesc.getEntityPrefix() : "";
+        String entityName = entityPrefix + entityDesc.getSimpleName();
         String tableName = entityDesc.getTableName();
         return !tableName.equalsIgnoreCase(namingType.apply(entityName));
     }

--- a/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
@@ -176,7 +176,7 @@ public class EntityDescFactory {
         entityDesc.setTableName(tableMeta.getName());
         entityDesc.setQualifiedTableName(tableMeta.getQualifiedTableName());
         entityDesc.setPackageName(packageName);
-        entityDesc.setEntityPrefix(Objects.nonNull(entityPrefix) ? entityPrefix : "");
+        entityDesc.setEntityPrefix(StringUtil.defaultString(entityPrefix, ""));
         entityDesc.setSimpleName(simpleName);
         if (superclass != null) {
             entityDesc.setSuperclassSimpleName(superclass.getSimpleName());
@@ -221,8 +221,7 @@ public class EntityDescFactory {
      * @return エンティティ名とテーブル名が異なる場合 {@code true}
      */
     protected boolean isNameDifferentBetweenEntityAndTable(EntityDesc entityDesc) {
-        String entityPrefix = Objects.nonNull(entityDesc.getEntityPrefix()) ?
-                entityDesc.getEntityPrefix() : "";
+        String entityPrefix = StringUtil.defaultString(entityDesc.getEntityPrefix(), "");
         String entityName = entityPrefix + entityDesc.getSimpleName();
         String tableName = entityDesc.getTableName();
         return !tableName.equalsIgnoreCase(namingType.apply(entityName));

--- a/src/main/java/org/seasar/doma/extension/gen/EntityListenerDesc.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityListenerDesc.java
@@ -31,6 +31,9 @@ public class EntityListenerDesc extends ClassDesc {
     /** リスナークラスの単純名 */
     protected String listenerClassSimpleName;
 
+    /** エンティティ記述 */
+    protected EntityDesc entityDesc;
+
     /** テンプレート名 */
     protected String templateName;
 
@@ -110,4 +113,22 @@ public class EntityListenerDesc extends ClassDesc {
         this.listenerClassSimpleName = listenerClassSimpleName;
     }
 
+    /**
+     * エンティティ記述を返します。
+     *
+     * @return エンティティ記述
+     */
+    public EntityDesc getEntityDesc() {
+        return entityDesc;
+    }
+
+    /**
+     * エンティティ記述を設定します。
+     *
+     * @param entityDesc
+     *            エンティティ記述
+     */
+    public void setEntityDesc(EntityDesc entityDesc) {
+        this.entityDesc = entityDesc;
+    }
 }

--- a/src/main/java/org/seasar/doma/extension/gen/EntityListenerDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityListenerDescFactory.java
@@ -17,6 +17,8 @@ package org.seasar.doma.extension.gen;
 
 import org.seasar.doma.extension.gen.internal.util.ClassUtil;
 
+import java.util.Objects;
+
 /**
  * エンティティ記述のファクトリです。
  * 
@@ -55,8 +57,12 @@ public class EntityListenerDescFactory {
      */
     public EntityListenerDesc createEntityListenerDesc(EntityDesc entityDesc) {
         EntityListenerDesc entityListenerDesc = new EntityListenerDesc();
+        entityListenerDesc.setEntityDesc(entityDesc);
         entityListenerDesc.setPackageName(entityDesc.getPackageName());
-        entityListenerDesc.setSimpleName(entityDesc.getSimpleName()
+        String entityPrefix = Objects.nonNull(entityDesc.getEntityPrefix()) ?
+                entityDesc.getEntityPrefix() : "";
+        String entityName = entityPrefix + entityDesc.getSimpleName();
+        entityListenerDesc.setSimpleName(entityName
                 + Constants.ENTITY_LISTENER_SUFFIX);
         entityListenerDesc.setEntityClassSimpleName(entityDesc.getSimpleName());
         if (superclassName != null) {

--- a/src/main/java/org/seasar/doma/extension/gen/EntityListenerDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityListenerDescFactory.java
@@ -18,8 +18,6 @@ package org.seasar.doma.extension.gen;
 import org.seasar.doma.extension.gen.internal.util.ClassUtil;
 import org.seasar.doma.extension.gen.internal.util.StringUtil;
 
-import java.util.Objects;
-
 /**
  * エンティティ記述のファクトリです。
  * 

--- a/src/main/java/org/seasar/doma/extension/gen/EntityListenerDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityListenerDescFactory.java
@@ -16,6 +16,7 @@
 package org.seasar.doma.extension.gen;
 
 import org.seasar.doma.extension.gen.internal.util.ClassUtil;
+import org.seasar.doma.extension.gen.internal.util.StringUtil;
 
 import java.util.Objects;
 
@@ -59,8 +60,7 @@ public class EntityListenerDescFactory {
         EntityListenerDesc entityListenerDesc = new EntityListenerDesc();
         entityListenerDesc.setEntityDesc(entityDesc);
         entityListenerDesc.setPackageName(entityDesc.getPackageName());
-        String entityPrefix = Objects.nonNull(entityDesc.getEntityPrefix()) ?
-                entityDesc.getEntityPrefix() : "";
+        String entityPrefix = StringUtil.defaultString(entityDesc.getEntityPrefix(), "");
         String entityName = entityPrefix + entityDesc.getSimpleName();
         entityListenerDesc.setSimpleName(entityName
                 + Constants.ENTITY_LISTENER_SUFFIX);

--- a/src/main/java/org/seasar/doma/extension/gen/internal/util/StringUtil.java
+++ b/src/main/java/org/seasar/doma/extension/gen/internal/util/StringUtil.java
@@ -124,4 +124,16 @@ public final class StringUtil {
         return text == null || text.isEmpty();
     }
 
+    /**
+     * {@param str} が {@code null} の場合 {@param defaultStr} を返します。
+     *
+     * @param str
+     *            文字列
+     * @param defaultStr
+     *            nullの場合のデフォルト文字列
+     * @return {@code text} が {@code null} もしくは空文字の場合 {@code true}
+     */
+    public static String defaultString(final String str, final String defaultStr) {
+        return str == null ? defaultStr : str;
+    }
 }

--- a/src/main/java/org/seasar/doma/extension/gen/internal/util/StringUtil.java
+++ b/src/main/java/org/seasar/doma/extension/gen/internal/util/StringUtil.java
@@ -125,13 +125,13 @@ public final class StringUtil {
     }
 
     /**
-     * {@param str} が {@code null} の場合 {@param defaultStr} を返します。
+     * {@code str} が {@code null} の場合 {@code defaultStr} を返します。
      *
      * @param str
      *            文字列
      * @param defaultStr
      *            nullの場合のデフォルト文字列
-     * @return {@code text} が {@code null} もしくは空文字の場合 {@code true}
+     * @return 文字列
      */
     public static String defaultString(final String str, final String defaultStr) {
         return str == null ? defaultStr : str;

--- a/src/main/java/org/seasar/doma/extension/gen/task/EntityConfig.java
+++ b/src/main/java/org/seasar/doma/extension/gen/task/EntityConfig.java
@@ -95,6 +95,8 @@ public class EntityConfig extends DataType {
 
     protected String sql = null;
 
+    protected String entityPrefix;
+
     protected String entityName = "Example";
 
     public boolean isGenerate() {
@@ -280,6 +282,14 @@ public class EntityConfig extends DataType {
 
     public void setSql(String sql) {
         this.sql = sql;
+    }
+
+    public String getEntityPrefix() {
+        return entityPrefix;
+    }
+
+    public void setEntityPrefix(String entityPrefix) {
+        this.entityPrefix = entityPrefix;
     }
 
     public String getEntityName() {

--- a/src/main/java/org/seasar/doma/extension/gen/task/Gen.java
+++ b/src/main/java/org/seasar/doma/extension/gen/task/Gen.java
@@ -20,6 +20,7 @@ import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringTokenizer;
 
 import javax.sql.DataSource;
@@ -578,7 +579,7 @@ public class Gen extends AbstractTask {
             }
             for (TableMeta tableMeta : tableMetas) {
                 EntityDesc entityDesc = entityDescFactory
-                        .createEntityDesc(tableMeta);
+                        .createEntityDesc(tableMeta, entityConfig.getEntityPrefix());
                 if (entityConfig.isGenerate()) {
                     generateEntity(entityDesc);
                     if (entityConfig.isUseListener()) {
@@ -611,6 +612,7 @@ public class Gen extends AbstractTask {
                 dataSource);
         TableMeta tableMeta = reader.read(entityConfig.getSql());
         EntityDesc entityDesc = entityDescFactory.createEntityDesc(tableMeta,
+                entityConfig.getEntityPrefix(),
                 entityConfig.getEntityName());
         generateEntity(entityDesc);
     }
@@ -630,6 +632,13 @@ public class Gen extends AbstractTask {
         generator.generate(context);
     }
 
+
+    /**
+     * エンティティリスナーのJavaコードを生成します。
+     *
+     * @param entityListenerDesc
+     *            エンティティリスナー記述
+     */
     protected void generateEntityListener(EntityListenerDesc entityListenerDesc) {
         File javaFile = FileUtil.createJavaFile(entityConfig.getDestDir(),
                 entityListenerDesc.getQualifiedName());

--- a/src/main/resources/org/seasar/doma/extension/gen/template/dao.ftl
+++ b/src/main/resources/org/seasar/doma/extension/gen/template/dao.ftl
@@ -24,10 +24,10 @@ public interface ${simpleName} {
 <#list entityDesc.idEntityPropertyDescs as property>
      * @param ${property.name}
 </#list>
-     * @return the ${entityDesc.simpleName} entity
+     * @return the <#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} entity
      */
     @Select
-    ${entityDesc.simpleName} selectById(<#list entityDesc.idEntityPropertyDescs as property>${property.propertyClassSimpleName} ${property.name}<#if property_has_next>, </#if></#list>);
+    <#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} selectById(<#list entityDesc.idEntityPropertyDescs as property>${property.propertyClassSimpleName} ${property.name}<#if property_has_next>, </#if></#list>);
 
 </#if>
 <#if entityDesc.idEntityPropertyDescs?size gt 0 && entityDesc.versionEntityPropertyDesc??>
@@ -36,10 +36,10 @@ public interface ${simpleName} {
      * @param ${property.name}
 </#list>
      * @param ${entityDesc.versionEntityPropertyDesc.name}
-     * @return the ${entityDesc.simpleName} entity
+     * @return the <#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} entity
      */
     @Select(ensureResult = true)
-    ${entityDesc.simpleName} selectByIdAndVersion(<#list entityDesc.idEntityPropertyDescs as property>${property.propertyClassSimpleName} ${property.name}, </#list>${entityDesc.versionEntityPropertyDesc.propertyClassSimpleName} ${entityDesc.versionEntityPropertyDesc.name});
+    <#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} selectByIdAndVersion(<#list entityDesc.idEntityPropertyDescs as property>${property.propertyClassSimpleName} ${property.name}, </#list>${entityDesc.versionEntityPropertyDesc.propertyClassSimpleName} ${entityDesc.versionEntityPropertyDesc.name});
 
 </#if>
     /**
@@ -47,19 +47,19 @@ public interface ${simpleName} {
      * @return affected rows
      */
     @Insert
-    int insert(${entityDesc.simpleName} entity);
+    int insert(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} entity);
 
     /**
      * @param entity
      * @return affected rows
      */
     @Update
-    int update(${entityDesc.simpleName} entity);
+    int update(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} entity);
 
     /**
      * @param entity
      * @return affected rows
      */
     @Delete
-    int delete(${entityDesc.simpleName} entity);
+    int delete(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityDesc.simpleName} entity);
 }

--- a/src/main/resources/org/seasar/doma/extension/gen/template/entity.ftl
+++ b/src/main/resources/org/seasar/doma/extension/gen/template/entity.ftl
@@ -23,7 +23,7 @@ import ${importName};
 <#if showCatalogName && catalogName?? || showSchemaName && schemaName?? || showTableName && tableName??>
 @Table(<#if showCatalogName && catalogName??>catalog = "${catalogName}"</#if><#if showSchemaName && schemaName??><#if showCatalogName && catalogName??>, </#if>schema = "${schemaName}"</#if><#if showTableName><#if showCatalogName && catalogName?? || showSchemaName && schemaName??>, </#if>name = "${tableName}"</#if>)
 </#if>
-public class ${simpleName}<#if superclassSimpleName??> extends ${superclassSimpleName}</#if> {
+public class <#if entityPrefix??>${entityPrefix}</#if>${simpleName}<#if superclassSimpleName??> extends ${superclassSimpleName}</#if> {
 <#list ownEntityPropertyDescs as property>
 
   <#if showDbComment && property.comment??>
@@ -54,7 +54,7 @@ public class ${simpleName}<#if superclassSimpleName??> extends ${superclassSimpl
 
     /** */
     @OriginalStates
-    ${simpleName} ${originalStatesPropertyName};
+    <#if entityPrefix??>${entityPrefix}</#if>${simpleName} ${originalStatesPropertyName};
 </#if>
 <#if useAccessor>
   <#list ownEntityPropertyDescs as property>

--- a/src/main/resources/org/seasar/doma/extension/gen/template/entityListener.ftl
+++ b/src/main/resources/org/seasar/doma/extension/gen/template/entityListener.ftl
@@ -17,31 +17,31 @@ import ${importName};
  * @author ${lib.author}
 </#if>
  */
-public class ${simpleName}<#if superclassSimpleName??> extends ${superclassSimpleName}<${entityClassSimpleName}><#else> implements EntityListener<${entityClassSimpleName}></#if> {
+public class ${simpleName}<#if superclassSimpleName??> extends ${superclassSimpleName}<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}><#else> implements EntityListener<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}></#if> {
 <#if !superclassSimpleName??>
 
     @Override
-    public void preInsert(${entityClassSimpleName} entity, PreInsertContext<${entityClassSimpleName}> context) {
+    public void preInsert(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName} entity, PreInsertContext<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}> context) {
     }
 
     @Override
-    public void preUpdate(${entityClassSimpleName} entity, PreUpdateContext<${entityClassSimpleName}> context) {
+    public void preUpdate(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName} entity, PreUpdateContext<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}> context) {
     }
 
     @Override
-    public void preDelete(${entityClassSimpleName} entity, PreDeleteContext<${entityClassSimpleName}> context) {
+    public void preDelete(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName} entity, PreDeleteContext<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}> context) {
     }
 
     @Override
-    public void postInsert(${entityClassSimpleName} entity, PostInsertContext<${entityClassSimpleName}> context) {
+    public void postInsert(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName} entity, PostInsertContext<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}> context) {
     }
 
     @Override
-    public void postUpdate(${entityClassSimpleName} entity, PostUpdateContext<${entityClassSimpleName}> context) {
+    public void postUpdate(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName} entity, PostUpdateContext<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}> context) {
     }
 
     @Override
-    public void postDelete(${entityClassSimpleName} entity, PostDeleteContext<${entityClassSimpleName}> context) {
+    public void postDelete(<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName} entity, PostDeleteContext<<#if entityDesc.entityPrefix??>${entityDesc.entityPrefix}</#if>${entityClassSimpleName}> context) {
     }
 </#if>
 }

--- a/src/main/resources/org/seasar/doma/extension/gen/template/sqlTestCase.ftl
+++ b/src/main/resources/org/seasar/doma/extension/gen/template/sqlTestCase.ftl
@@ -26,7 +26,7 @@ import org.seasar.doma.jdbc.dialect.Dialect;
  * @author ${lib.author}
 </#if>
  */
-public class ${simpleName} extends TestCase {
+public class <#if entityPrefix??>${entityPrefix}</#if>${simpleName} extends TestCase {
 
     /** */
     protected SqlFileRepository repository;

--- a/src/test/java/org/seasar/doma/extension/gen/GeneratorTest.java
+++ b/src/test/java/org/seasar/doma/extension/gen/GeneratorTest.java
@@ -81,6 +81,47 @@ public class GeneratorTest extends TestCase {
         assertEquals(expect(), generator.getResult());
     }
 
+    public void testSimpleEntity_with_prefix() throws Exception {
+        ColumnMeta id = new ColumnMeta();
+        id.setComment("COMMENT for ID");
+        id.setName("ID");
+        id.setTypeName("integer");
+        id.setPrimaryKey(true);
+        id.setNullable(false);
+
+        ColumnMeta empName = new ColumnMeta();
+        empName.setComment("COMMENT for NAME");
+        empName.setName("EMP_NAME");
+        empName.setTypeName("varcar");
+
+        ColumnMeta version = new ColumnMeta();
+        version.setComment("COMMENT for VERSION");
+        version.setName("VERSION");
+        version.setTypeName("integer");
+
+        TableMeta tableMeta = new TableMeta();
+        tableMeta.setCatalogName("CATALOG");
+        tableMeta.setSchemaName("SCHEMA");
+        tableMeta.setName("HOGE");
+        tableMeta.setComment("COMMENT for HOGE");
+        tableMeta.addColumnMeta(id);
+        tableMeta.addColumnMeta(empName);
+        tableMeta.addColumnMeta(version);
+
+        EntityPropertyClassNameResolver resolver = factory
+                .createEntityPropertyClassNameResolver(null);
+        EntityPropertyDescFactory entityPropertyDescFactory = factory
+                .createEntityPropertyDescFactory(dialect, resolver, "version",
+                        null, 100L, 50L, true);
+        EntityDescFactory entityDescFactory = factory.createEntityDescFactory(
+                "example.entity", null, entityPropertyDescFactory,
+                NamingType.NONE, null, false, false, true, true, true, false);
+        EntityDesc entityDesc = entityDescFactory.createEntityDesc(tableMeta, "T");
+        generator.generate(new EntityContext(entityDesc));
+
+        assertEquals(expect(), generator.getResult());
+    }
+
     public void testOriginalStates() throws Exception {
         ColumnMeta id = new ColumnMeta();
         id.setComment("COMMENT for ID");
@@ -494,6 +535,39 @@ public class GeneratorTest extends TestCase {
         assertEquals(expect(), generator.getResult());
     }
 
+    public void testSimpleEntityListener_with_prefix() throws Exception {
+        ColumnMeta id = new ColumnMeta();
+        id.setComment("COMMENT for ID");
+        id.setName("ID");
+        id.setTypeName("integer");
+        id.setPrimaryKey(true);
+        id.setNullable(false);
+
+        TableMeta tableMeta = new TableMeta();
+        tableMeta.setCatalogName("CATALOG");
+        tableMeta.setSchemaName("SCHEMA");
+        tableMeta.setName("HOGE");
+        tableMeta.setComment("COMMENT for HOGE");
+        tableMeta.addColumnMeta(id);
+
+        EntityPropertyClassNameResolver resolver = factory
+                .createEntityPropertyClassNameResolver(null);
+        EntityPropertyDescFactory entityPropertyDescFactory = factory
+                .createEntityPropertyDescFactory(dialect, resolver, "version",
+                        null, 100L, 50L, true);
+        EntityDescFactory entityDescFactory = factory.createEntityDescFactory(
+                "example.entity", null, entityPropertyDescFactory,
+                NamingType.NONE, null, false, false, true, true, true, false);
+        EntityDesc entityDesc = entityDescFactory.createEntityDesc(tableMeta, "T");
+        EntityListenerDescFactory entityListenerDescFactory = factory
+                .createEntityListenerDescFactory("example.entity", null);
+        EntityListenerDesc entityListenerDesc = entityListenerDescFactory
+                .createEntityListenerDesc(entityDesc);
+        generator.generate(new EntityListenerContext(entityListenerDesc));
+
+        assertEquals(expect(), generator.getResult());
+    }
+
     public void testExtendingEntityListener() throws Exception {
         ColumnMeta id = new ColumnMeta();
         id.setComment("COMMENT for ID");
@@ -558,6 +632,45 @@ public class GeneratorTest extends TestCase {
                 "example.entity", null, entityPropertyDescFactory,
                 NamingType.NONE, null, false, false, true, true, true, false);
         EntityDesc entityDesc = entityDescFactory.createEntityDesc(tableMeta);
+
+        DaoDescFactory daoDescFactory = factory.createDaoDescFactory(
+                "example.dao", "Dao", "dao.config.MyConfig");
+        DaoDesc daoDesc = daoDescFactory.createDaoDesc(entityDesc);
+        generator.generate(new DaoContext(daoDesc));
+
+        assertEquals(expect(), generator.getResult());
+    }
+
+    public void testSimpleDao_with_prefix() throws Exception {
+        ColumnMeta id = new ColumnMeta();
+        id.setComment("COMMENT for ID");
+        id.setName("ID");
+        id.setTypeName("integer");
+        id.setPrimaryKey(true);
+        id.setNullable(false);
+
+        ColumnMeta version = new ColumnMeta();
+        version.setComment("COMMENT for VERSION");
+        version.setName("VERSION");
+        version.setTypeName("integer");
+
+        TableMeta tableMeta = new TableMeta();
+        tableMeta.setCatalogName("CATALOG");
+        tableMeta.setSchemaName("SCHEMA");
+        tableMeta.setName("HOGE");
+        tableMeta.setComment("COMMENT for HOGE");
+        tableMeta.addColumnMeta(id);
+        tableMeta.addColumnMeta(version);
+
+        EntityPropertyClassNameResolver resolver = factory
+                .createEntityPropertyClassNameResolver(null);
+        EntityPropertyDescFactory entityPropertyDescFactory = factory
+                .createEntityPropertyDescFactory(dialect, resolver, "version",
+                        null, 100L, 50L, true);
+        EntityDescFactory entityDescFactory = factory.createEntityDescFactory(
+                "example.entity", null, entityPropertyDescFactory,
+                NamingType.NONE, null, false, false, true, true, true, false);
+        EntityDesc entityDesc = entityDescFactory.createEntityDesc(tableMeta, "T");
 
         DaoDescFactory daoDescFactory = factory.createDaoDescFactory(
                 "example.dao", "Dao", "dao.config.MyConfig");

--- a/src/test/resources/org/seasar/doma/extension/gen/GeneratorTest_SimpleDao_with_prefix.txt
+++ b/src/test/resources/org/seasar/doma/extension/gen/GeneratorTest_SimpleDao_with_prefix.txt
@@ -1,0 +1,51 @@
+package example.dao;
+
+import dao.config.MyConfig;
+import example.entity.THoge;
+import org.seasar.doma.Dao;
+import org.seasar.doma.Delete;
+import org.seasar.doma.Insert;
+import org.seasar.doma.Select;
+import org.seasar.doma.Update;
+
+/**
+ */
+@Dao(config = MyConfig.class)
+public interface THogeDao {
+
+    /**
+     * @param id
+     * @return the THoge entity
+     */
+    @Select
+    THoge selectById(Integer id);
+
+    /**
+     * @param id
+     * @param version
+     * @return the THoge entity
+     */
+    @Select(ensureResult = true)
+    THoge selectByIdAndVersion(Integer id, Integer version);
+
+    /**
+     * @param entity
+     * @return affected rows
+     */
+    @Insert
+    int insert(THoge entity);
+
+    /**
+     * @param entity
+     * @return affected rows
+     */
+    @Update
+    int update(THoge entity);
+
+    /**
+     * @param entity
+     * @return affected rows
+     */
+    @Delete
+    int delete(THoge entity);
+}

--- a/src/test/resources/org/seasar/doma/extension/gen/GeneratorTest_SimpleEntityListener_with_prefix.txt
+++ b/src/test/resources/org/seasar/doma/extension/gen/GeneratorTest_SimpleEntityListener_with_prefix.txt
@@ -1,0 +1,39 @@
+package example.entity;
+
+import org.seasar.doma.jdbc.entity.EntityListener;
+import org.seasar.doma.jdbc.entity.PostDeleteContext;
+import org.seasar.doma.jdbc.entity.PostInsertContext;
+import org.seasar.doma.jdbc.entity.PostUpdateContext;
+import org.seasar.doma.jdbc.entity.PreDeleteContext;
+import org.seasar.doma.jdbc.entity.PreInsertContext;
+import org.seasar.doma.jdbc.entity.PreUpdateContext;
+
+/**
+ * 
+ */
+public class THogeListener implements EntityListener<THoge> {
+
+    @Override
+    public void preInsert(THoge entity, PreInsertContext<THoge> context) {
+    }
+
+    @Override
+    public void preUpdate(THoge entity, PreUpdateContext<THoge> context) {
+    }
+
+    @Override
+    public void preDelete(THoge entity, PreDeleteContext<THoge> context) {
+    }
+
+    @Override
+    public void postInsert(THoge entity, PostInsertContext<THoge> context) {
+    }
+
+    @Override
+    public void postUpdate(THoge entity, PostUpdateContext<THoge> context) {
+    }
+
+    @Override
+    public void postDelete(THoge entity, PostDeleteContext<THoge> context) {
+    }
+}

--- a/src/test/resources/org/seasar/doma/extension/gen/GeneratorTest_SimpleEntity_with_prefix.txt
+++ b/src/test/resources/org/seasar/doma/extension/gen/GeneratorTest_SimpleEntity_with_prefix.txt
@@ -1,0 +1,83 @@
+package example.entity;
+
+import org.seasar.doma.Column;
+import org.seasar.doma.Entity;
+import org.seasar.doma.Id;
+import org.seasar.doma.Table;
+import org.seasar.doma.Version;
+
+/**
+ * COMMENT for HOGE
+ */
+@Entity
+@Table(name = "HOGE")
+public class THoge {
+
+    /** COMMENT for ID */
+    @Id
+    @Column(name = "ID")
+    Integer id;
+
+    /** COMMENT for NAME */
+    @Column(name = "EMP_NAME")
+    String empName;
+
+    /** COMMENT for VERSION */
+    @Version
+    @Column(name = "VERSION")
+    Integer version;
+
+    /** 
+     * Returns the id.
+     * 
+     * @return the id
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    /** 
+     * Sets the id.
+     * 
+     * @param id the id
+     */
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /** 
+     * Returns the empName.
+     * 
+     * @return the empName
+     */
+    public String getEmpName() {
+        return empName;
+    }
+
+    /** 
+     * Sets the empName.
+     * 
+     * @param empName the empName
+     */
+    public void setEmpName(String empName) {
+        this.empName = empName;
+    }
+
+    /** 
+     * Returns the version.
+     * 
+     * @return the version
+     */
+    public Integer getVersion() {
+        return version;
+    }
+
+    /** 
+     * Sets the version.
+     * 
+     * @param version the version
+     */
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+}


### PR DESCRIPTION
業務システムでよくあるようなテーブル名にプリフィックス付ける慣習（例えば`T_ORDER`など）はWeb系ではあまり一般的じゃないのですが、
Javaではエンティティにはプリフィックス付けた方がわかりやすいというニーズがあったので追加してみました。

参考
https://twitter.com/kis/statuses/664651369236705280
