### PR TITLE
MySQLのEntityフィールドの型を修正

### DIFF
--- a/src/main/java/org/seasar/doma/extension/gen/ResultSetMetaReader.java
+++ b/src/main/java/org/seasar/doma/extension/gen/ResultSetMetaReader.java
@@ -82,7 +82,7 @@ public class ResultSetMetaReader {
             ColumnMeta columnMeta = new ColumnMeta();
             columnMeta.setName(rsmd.getColumnLabel(i));
             columnMeta.setSqlType(rsmd.getColumnType(i));
-            columnMeta.setTypeName(rsmd.getTableName(i));
+            columnMeta.setTypeName(rsmd.getTableName(i).toLowerCase());
             columnMeta.setLength(rsmd.getPrecision(i));
             columnMeta.setScale(rsmd.getScale(i));
             tableMeta.addColumnMeta(columnMeta);

--- a/src/main/java/org/seasar/doma/extension/gen/TableMetaReader.java
+++ b/src/main/java/org/seasar/doma/extension/gen/TableMetaReader.java
@@ -192,7 +192,7 @@ public class TableMetaReader {
                 ColumnMeta columnMeta = new ColumnMeta();
                 columnMeta.setName(rs.getString("COLUMN_NAME"));
                 columnMeta.setSqlType(rs.getInt("DATA_TYPE"));
-                columnMeta.setTypeName(rs.getString("TYPE_NAME"));
+                columnMeta.setTypeName(rs.getString("TYPE_NAME").toLowerCase());
                 columnMeta.setLength(rs.getInt("COLUMN_SIZE"));
                 columnMeta.setScale(rs.getInt("DECIMAL_DIGITS"));
                 columnMeta.setNullable(rs.getBoolean("NULLABLE"));

--- a/src/main/java/org/seasar/doma/extension/gen/dialect/Mssql2008GenDialect.java
+++ b/src/main/java/org/seasar/doma/extension/gen/dialect/Mssql2008GenDialect.java
@@ -73,7 +73,7 @@ public class Mssql2008GenDialect extends StandardGenDialect {
 
     @Override
     public String getMappedPropertyClassName(ColumnMeta columnMeta) {
-        String typeName = columnMeta.getTypeName().toLowerCase();
+        String typeName = columnMeta.getTypeName();
         if (typeName.startsWith("int")) {
             typeName = "int";
         } else if (typeName.startsWith("bigint")) {

--- a/src/main/java/org/seasar/doma/extension/gen/dialect/MysqlGenDialect.java
+++ b/src/main/java/org/seasar/doma/extension/gen/dialect/MysqlGenDialect.java
@@ -72,7 +72,7 @@ public class MysqlGenDialect extends StandardGenDialect {
         classNameMap.put("time", LocalTime.class.getName());
         classNameMap.put("year", Short.class.getName());
 
-        // BLOB型とTEXT型
+        // BLOB型
         classNameMap.put("tinyblob", Blob.class.getName());
         classNameMap.put("blob", Blob.class.getName());
         classNameMap.put("mediumblob", Blob.class.getName());
@@ -95,12 +95,12 @@ public class MysqlGenDialect extends StandardGenDialect {
 
     @Override
     public String getMappedPropertyClassName(ColumnMeta columnMeta) {
-        if ("bit".equalsIgnoreCase(columnMeta.getTypeName()) ||
-                "tinyint".equalsIgnoreCase(columnMeta.getTypeName())) {
+        if ("bit".equals(columnMeta.getTypeName()) ||
+                "tinyint".equals(columnMeta.getTypeName())) {
             return columnMeta.getLength() <= 1 ? Boolean.class.getName()
                     : Byte.class.getName();
         }
-        if ("tinyint unsigned".equalsIgnoreCase(columnMeta.getTypeName())) {
+        if ("tinyint unsigned".equals(columnMeta.getTypeName())) {
             return columnMeta.getLength() <= 1 ? Boolean.class.getName()
                     : Short.class.getName();
         }

--- a/src/main/java/org/seasar/doma/extension/gen/dialect/MysqlGenDialect.java
+++ b/src/main/java/org/seasar/doma/extension/gen/dialect/MysqlGenDialect.java
@@ -15,11 +15,12 @@
  */
 package org.seasar.doma.extension.gen.dialect;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Date;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import org.seasar.doma.extension.gen.ClassConstants;
 import org.seasar.doma.extension.gen.ColumnMeta;
@@ -34,25 +35,52 @@ public class MysqlGenDialect extends StandardGenDialect {
 
     /**
      * インスタンスを構築します。
+     *
+     * @see <a href="https://dev.mysql.com/doc/refman/5.6/ja/data-types.html">MySQL 5.6 リファレンスマニュアル / データ型</a>
+     * @see <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-type-conversions.html">MySQL Connector/J Developer Guide / Java, JDBC and MySQL Types</a>
      */
     public MysqlGenDialect() {
-        classNameMap.put("bigint unsigned", BigInteger.class.getName());
-        classNameMap.put("datetime", LocalDateTime.class.getName());
-        classNameMap.put("int", Integer.class.getName());
-        classNameMap.put("int unsigned", Long.class.getName());
-        classNameMap.put("longblob", Blob.class.getName());
-        classNameMap.put("longtext", Clob.class.getName());
-        classNameMap.put("mediumblob", Blob.class.getName());
+        // 数値型
+        classNameMap.put("bool", Boolean.class.getName());
+        classNameMap.put("boolean", Boolean.class.getName());
+        classNameMap.put("smallint", Short.class.getName());
+        classNameMap.put("smallint unsigned", Integer.class.getName());
         classNameMap.put("mediumint", Integer.class.getName());
         classNameMap.put("mediumint unsigned", Integer.class.getName());
-        classNameMap.put("mediumtext", Clob.class.getName());
-        classNameMap.put("smallint unsigned", Integer.class.getName());
+        classNameMap.put("int", Integer.class.getName());
+        classNameMap.put("int unsigned", Long.class.getName());
+        classNameMap.put("integer", Integer.class.getName());
+        classNameMap.put("integer unsigned", Long.class.getName());
+        classNameMap.put("bigint", Long.class.getName());
+        classNameMap.put("bigint unsigned", BigInteger.class.getName());
+        classNameMap.put("serial", BigInteger.class.getName());
+        classNameMap.put("decimal", BigDecimal.class.getName());
+        classNameMap.put("decimal unsigned", BigDecimal.class.getName());
+        classNameMap.put("dec", BigDecimal.class.getName());
+        classNameMap.put("dec unsigned", BigDecimal.class.getName());
+        classNameMap.put("float", Float.class.getName());
+        classNameMap.put("float unsigned", Float.class.getName());
+        classNameMap.put("double", Double.class.getName());
+        classNameMap.put("double unsigned", Double.class.getName());
+        classNameMap.put("double precision", Double.class.getName());
+        classNameMap.put("double precision unsigned", Double.class.getName());
+
+        // 日付と時間型
+        classNameMap.put("date", LocalDate.class.getName());
+        classNameMap.put("datetime", LocalDateTime.class.getName());
+        classNameMap.put("timestamp", LocalDateTime.class.getName());
+        classNameMap.put("time", LocalTime.class.getName());
+        classNameMap.put("year", Short.class.getName());
+
+        // BLOB型とTEXT型
         classNameMap.put("tinyblob", Blob.class.getName());
-        classNameMap.put("tinyint", Byte.class.getName());
-        classNameMap.put("tinyint unsigned", Short.class.getName());
-        classNameMap.put("tinytext", Clob.class.getName());
-        classNameMap.put("text", Clob.class.getName());
-        classNameMap.put("year", Date.class.getName());
+        classNameMap.put("blob", Blob.class.getName());
+        classNameMap.put("mediumblob", Blob.class.getName());
+        classNameMap.put("longblob", Blob.class.getName());
+
+        // BINARYおよびVARBINARY型
+        classNameMap.put("binary", ClassConstants.bytes.getQualifiedName());
+        classNameMap.put("varbinary", ClassConstants.bytes.getQualifiedName());
     }
 
     @Override
@@ -67,9 +95,14 @@ public class MysqlGenDialect extends StandardGenDialect {
 
     @Override
     public String getMappedPropertyClassName(ColumnMeta columnMeta) {
-        if ("bit".equalsIgnoreCase(columnMeta.getTypeName())) {
-            return columnMeta.getLength() == 1 ? Boolean.class.getName()
-                    : ClassConstants.bytes.getQualifiedName();
+        if ("bit".equalsIgnoreCase(columnMeta.getTypeName()) ||
+                "tinyint".equalsIgnoreCase(columnMeta.getTypeName())) {
+            return columnMeta.getLength() <= 1 ? Boolean.class.getName()
+                    : Byte.class.getName();
+        }
+        if ("tinyint unsigned".equalsIgnoreCase(columnMeta.getTypeName())) {
+            return columnMeta.getLength() <= 1 ? Boolean.class.getName()
+                    : Short.class.getName();
         }
         return super.getMappedPropertyClassName(columnMeta);
     }

--- a/src/main/java/org/seasar/doma/extension/gen/dialect/OracleGenDialect.java
+++ b/src/main/java/org/seasar/doma/extension/gen/dialect/OracleGenDialect.java
@@ -136,7 +136,7 @@ public class OracleGenDialect extends StandardGenDialect {
 
     @Override
     public String getMappedPropertyClassName(ColumnMeta columnMeta) {
-        if ("number".equalsIgnoreCase(columnMeta.getTypeName())) {
+        if ("number".equals(columnMeta.getTypeName())) {
             if (columnMeta.getScale() != 0) {
                 return BigDecimal.class.getName();
             }

--- a/src/test/java/org/seasar/doma/extension/gen/dialect/MysqlGenDialectTest.java
+++ b/src/test/java/org/seasar/doma/extension/gen/dialect/MysqlGenDialectTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2004-2016 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.extension.gen.dialect;
+
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import org.seasar.doma.extension.gen.ColumnMeta;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author matsumana
+ */
+@RunWith(Theories.class)
+public class MysqlGenDialectTest {
+
+    @DataPoints
+    public static Fixture[] params = {
+            // 数値型
+            new Fixture("bit", 1, "java.lang.Boolean"),
+            new Fixture("bit", 2, "java.lang.Byte"),
+            new Fixture("tinyint", 1, "java.lang.Boolean"),
+            new Fixture("tinyint", 2, "java.lang.Byte"),
+            new Fixture("bool", "java.lang.Boolean"),
+            new Fixture("boolean", "java.lang.Boolean"),
+            new Fixture("smallint", "java.lang.Short"),
+            new Fixture("mediumint", "java.lang.Integer"),
+            new Fixture("int", "java.lang.Integer"),
+            new Fixture("integer", "java.lang.Integer"),
+            new Fixture("bigint", "java.lang.Long"),
+            new Fixture("serial", "java.math.BigInteger"),
+            new Fixture("decimal", "java.math.BigDecimal"),
+            new Fixture("dec", "java.math.BigDecimal"),
+            new Fixture("float", "java.lang.Float"),
+            new Fixture("double", "java.lang.Double"),
+            new Fixture("double precision", "java.lang.Double"),
+            new Fixture("tinyint unsigned", 1, "java.lang.Boolean"),
+            new Fixture("tinyint unsigned", 2, "java.lang.Short"),
+            new Fixture("smallint unsigned", "java.lang.Integer"),
+            new Fixture("mediumint unsigned", "java.lang.Integer"),
+            new Fixture("int unsigned", "java.lang.Long"),
+            new Fixture("integer unsigned", "java.lang.Long"),
+            new Fixture("bigint unsigned", "java.math.BigInteger"),
+            new Fixture("decimal unsigned", "java.math.BigDecimal"),
+            new Fixture("dec unsigned", "java.math.BigDecimal"),
+            new Fixture("float unsigned", "java.lang.Float"),
+            new Fixture("double unsigned", "java.lang.Double"),
+            new Fixture("double precision unsigned", "java.lang.Double"),
+
+            // 日付と時間型
+            new Fixture("date", "java.time.LocalDate"),
+            new Fixture("datetime", "java.time.LocalDateTime"),
+            new Fixture("timestamp", "java.time.LocalDateTime"),
+            new Fixture("time", "java.time.LocalTime"),
+            new Fixture("year", "java.lang.Short"),
+
+            // BLOB型とTEXT型
+            new Fixture("tinyblob", "java.sql.Blob"),
+            new Fixture("blob", "java.sql.Blob"),
+            new Fixture("mediumblob", "java.sql.Blob"),
+            new Fixture("longblob", "java.sql.Blob"),
+
+            // BINARYおよびVARBINARY型
+            new Fixture("binary", ".byte[]"),
+            new Fixture("varbinary", ".byte[]"),
+    };
+
+    @Theory
+    public void theory(Fixture param) {
+        MysqlGenDialect sut = new MysqlGenDialect();
+        ColumnMeta columnMeta = new ColumnMeta();
+        columnMeta.setTypeName(param.value);
+        columnMeta.setLength(param.length);
+        String actual = sut.getMappedPropertyClassName(columnMeta);
+
+        assertThat(actual, is(param.expected));
+    }
+
+    static class Fixture {
+        String value;
+        int length;
+        String expected;
+
+        Fixture(String value, String expected) {
+            this.value = value;
+            this.expected = expected;
+        }
+
+        Fixture(String value, int length, String expected) {
+            this.value = value;
+            this.length = length;
+            this.expected = expected;
+        }
+    }
+}

--- a/src/test/java/org/seasar/doma/extension/gen/internal/util/JdbcUtilTest.java
+++ b/src/test/java/org/seasar/doma/extension/gen/internal/util/JdbcUtilTest.java
@@ -29,6 +29,12 @@ public class JdbcUtilTest extends TestCase {
         assertEquals("postgres", dialectName);
     }
 
+    public void testInferDialectName_mysql() throws Exception {
+        String dialectName = JdbcUtil
+                .inferDialectName("jdbc:mysql://localhost:3306/hoge");
+        assertEquals("mysql", dialectName);
+    }
+
     public void testInferDialectName_unknown() throws Exception {
         String dialectName = JdbcUtil
                 .inferDialectName("jdbc:unknown://localhost/hoge");
@@ -44,6 +50,12 @@ public class JdbcUtilTest extends TestCase {
         String driverClassName = JdbcUtil
                 .inferDriverClassName("jdbc:postgresql://localhost/hoge");
         assertEquals("org.postgresql.Driver", driverClassName);
+    }
+
+    public void testInferDriverClassName_mysql() throws Exception {
+        String driverClassName = JdbcUtil
+                .inferDriverClassName("jdbc:mysql://localhost:3306/hoge");
+        assertEquals("com.mysql.jdbc.Driver", driverClassName);
     }
 
     public void testInferDriverClassName_unknown() throws Exception {


### PR DESCRIPTION
MySQLの場合、TYPE_NAMEが大文字だったのでMysqlGenDialectのコンストラクタで設定した内容が動作してませんでした。

このプルリクには含めていませんが、修正後のDoma-Genで出力したEntityでINSERT/SELECTのテストは行っています。
できれば、Doma-Genで実際に生成したEntityでINSERT/SELECTがちゃんと動くかのテストもこのリポジトリに含めたいのですが、
具体的な方法についてこのプルリクでご相談したいです。

また、TEXT型が`java.sql.Clob`になってましたが、個人的にはStringの方が扱いやすいと思います。
これについてもご意見を頂きたいです。

__参考URL__

* [MySQL 5.6 リファレンスマニュアル / データ型](https://dev.mysql.com/doc/refman/5.6/ja/data-types.html)
* [MySQL Connector/J Developer Guide / Java, JDBC and MySQL Types](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-type-conversions.html)