### PR TITLE
SQLを指定して単一のエンティティクラスを生成する際もエンティティの名前にサフィックスをつけられるようにする

### DIFF
--- a/src/main/java/org/seasar/doma/extension/gen/task/Gen.java
+++ b/src/main/java/org/seasar/doma/extension/gen/task/Gen.java
@@ -613,7 +613,7 @@ public class Gen extends AbstractTask {
                 dataSource);
         TableMeta tableMeta = reader.read(entityConfig.getSql());
         EntityDesc entityDesc = entityDescFactory.createEntityDesc(tableMeta,
-                entityConfig.getEntityPrefix(),
+                entityConfig.getEntityPrefix(), entityConfig.getEntitySuffix(),
                 entityConfig.getEntityName());
         generateEntity(entityDesc);
     }


### PR DESCRIPTION
#31 の修正漏れ対応