### PR TITLE
Entityのスーパークラスが何かextendsしている場合、無限ループとなってしまう不具合を解消しました

### DIFF
--- a/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
@@ -337,7 +337,7 @@ public class EntityDescFactory {
         if (superclass == null) {
             return results;
         }
-        for (Class<?> clazz = superclass; clazz != Object.class; clazz = superclass
+        for (Class<?> clazz = superclass; clazz != Object.class; clazz = clazz
                 .getSuperclass()) {
             Entity entity = clazz.getAnnotation(Entity.class);
             if (entity == null) {

--- a/src/test/java/example/hoge/AbstractBean.java
+++ b/src/test/java/example/hoge/AbstractBean.java
@@ -1,0 +1,5 @@
+package example.hoge;
+
+public abstract class AbstractBean {
+
+}

--- a/src/test/java/example/hoge/CommonEntity.java
+++ b/src/test/java/example/hoge/CommonEntity.java
@@ -23,7 +23,7 @@ import org.seasar.doma.Transient;
  * 
  */
 @Entity
-public class CommonEntity {
+public class CommonEntity extends AbstractBean {
 
     String name;
 


### PR DESCRIPTION
はじめまして。doma-gen使わせていただいております。
Entityのスーパークラスが何かextendsしている場合に無限ループとなってしまう不具合があったため、ソースを修正しました。
またテスト用にCommonEntityに別のクラスをextendsしています。
内容ご確認お願いします。