### PR TITLE
importName生成について、スーパークラスでのみ使用されているクラスの情報を除外しました

### DIFF
--- a/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
+++ b/src/main/java/org/seasar/doma/extension/gen/EntityDescFactory.java
@@ -404,7 +404,7 @@ public class EntityDescFactory {
                     ClassConstants.OriginalStates);
         }
         for (EntityPropertyDesc propertyDesc : entityDesc
-                .getEntityPropertyDescs()) {
+                .getOwnEntityPropertyDescs()) {
             if (propertyDesc.isId()) {
                 classDescSupport.addImportName(entityDesc, ClassConstants.Id);
                 if (propertyDesc.getGenerationType() != null) {


### PR DESCRIPTION
importName生成について、スーパークラスでのみ使用されているクラスの情報を除外するためgetOwnEntityPropertyDescsを使用するよう修正しました。
eclipseなどで、不要なインポートとして警告が発生していたためです。
ご確認よろしくお願いします。